### PR TITLE
Ensure we get ids as strings

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ const startStream = (client, streamParams) => {
     });
 };
 
-client.get('friends/ids', (error, response) => {
+client.get('friends/ids', {stringify_ids: true},(error, response) => {
     if(error) {
         console.log(error);
     }


### PR DESCRIPTION
Ensure we get ids as strings otherwise they are not correct (for some accounts!) when we parse them.