### PR TITLE
Feature/refactor followers

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ const http = require('http');
 const Twitter = require('twitter');
 const filter = require('./streams/filters');
 const error = require('./streams/error');
-
+const following = require('./streams/following');
 
 const conn = {
     consumer_key: process.env.consumer_key,
@@ -34,32 +34,78 @@ const conn = {
 console.log('Application started');
 const client = new Twitter(conn);
 
+// Get the rate usage for each endpoint.  Only show endpoints that have been used
 client.get('application/rate_limit_status', (err,response) => {
-    console.log(JSON.stringify(response));
-    if (err) console.log(JSON.stringify(err));
+    if (err) {
+        console.log(JSON.stringify(err));
+        return;
+    }
+    const used = [];
+    Object.keys(response.resources).forEach(key => {
+        Object.keys(response.resources[key]).forEach(endpointKey => {
+            const info = response.resources[key][endpointKey];
+            if (info.limit != info.remaining) {
+                used.push({
+                    limit: info.limit,
+                    remaining: info.remaining,
+                    reset: info.reset,
+                    endpoint: endpointKey
+                });
+            }
+        });
+    });
+    console.log(used);
 });
 
 console.log('Created connection to Twitter api for ' + conn.consumer_key);
 
+let streamHandle = null;
 const startStream = (client, streamParams) => { 
     client.stream('statuses/filter', streamParams, (stream) => {
+        streamHandle = stream;
         stream.on('data', (tweet) => filter.streamFilter(tweet, client));
         stream.on('error', error.streamError);
     });
 };
+const stopStream = () => {
+    streamHandle.destroy();
+    streamHandle = null;
+};
 
-client.get('friends/ids', (error, response) => {
-    if(error) {
-        console.log(error);
-    }
-    const following = response.ids.toString();
-    console.log('Following ' + response.ids.length + ' accounts: ' + following);
+// Get the list of followers and start the stream
+following.getFollowing(client)
+    .then((ids) => {
 
-    const streamParameters = {
-        follow: following
-    };
-    startStream(client, streamParameters);
-});
+        const followingStr = ids.toString();
+        console.log('Following ' + ids.length + ' accounts: ' + followingStr);
+        startStream(client, {
+            follow: followingStr
+        });
+    })
+    .catch((err) => {
+        err.streamError('Unable to start stream');
+    });
+
+// Setup a request to update the followers every 5 mins.  This is required by twitter API and should NOT be
+// modified or else we will get rate limited
+setInterval(() => {
+    following.getFollowing(client)
+        .then((oldIds) => {
+
+            following.updateFollowing(client)
+                .then((newIds) => {
+                    if (oldIds.length !== newIds.length) {
+                        console.log(`Following count changed from ${oldIds.length} to ${newIds.length}.  Restarting streams.`);
+                        stopStream();
+                        startStream(client, {
+                            follow: newIds.toString()
+                        });
+                    }
+                });
+
+        });
+},Math.floor(1000 * 60 * 5));
+
 
 // Load the http module to create an http server.
 

--- a/streams/filters/index.js
+++ b/streams/filters/index.js
@@ -31,7 +31,7 @@ module.exports.streamFilter  = (tweet, client) => {
             // Process the tweet on if we're following the account that tweeted it
             following.getFollowing(client)
                 .then((ids) => {
-                    if (ids.filter(id => id == tweet.user.id).length == 0) {
+                    if (ids.filter(id => id == tweet.user.id_str).length == 0) {
                         shouldProcess = false;
                     }
 

--- a/streams/following/index.js
+++ b/streams/following/index.js
@@ -1,0 +1,26 @@
+(function() {
+    let following = null;
+
+    updateFollowing = (client) => {
+        return new Promise((resolve,reject) => {
+            client.get('friends/ids', (error, response) => {
+                if(error) {
+                    console.log(error);
+                    reject(error);
+                }
+                following = response.ids;
+                resolve(following);
+            });
+        });
+    };
+
+    getFollowing = (client) => {
+      if (following === null){
+          return updateFollowing(client)
+      }
+      return Promise.resolve(following);
+    };
+
+    module.exports.getFollowing = getFollowing;
+    module.exports.updateFollowing = updateFollowing;
+})();

--- a/streams/following/index.js
+++ b/streams/following/index.js
@@ -3,7 +3,7 @@
 
     updateFollowing = (client) => {
         return new Promise((resolve,reject) => {
-            client.get('friends/ids', (error, response) => {
+            client.get('friends/ids', {stringify_ids: true}, (error, response) => {
                 if(error) {
                     console.log(error);
                     reject(error);


### PR DESCRIPTION
Change how the list of followers is queried.  Stored a cached list that is returned and periodically update the list from the twitter API.  

Change how tweets are processed.  Only process tweets from those we are following excluding retweets and mentions

Simplify the rate limit printing.  Only show endpoints that we have used.