### PR TITLE
Improve Slack Logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+// Log to console with timestamps
+console.logCopy = console.log.bind(console);
+console.log = function(data)
+{
+    var currentDate = '[' + new Date().toUTCString() + '] ';
+    this.logCopy(currentDate, data);
+};
+
 // Load the environment
 require('node-env-file')('.env', {raise: false});
  

--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ const Twitter = require('twitter');
 const filter = require('./streams/filters');
 const error = require('./streams/error');
 const following = require('./streams/following');
+const slack = require('./streams/slack');
 
 const conn = {
     consumer_key: process.env.consumer_key,
@@ -95,7 +96,11 @@ setInterval(() => {
             following.updateFollowing(client)
                 .then((newIds) => {
                     if (oldIds.length !== newIds.length) {
-                        console.log(`Following count changed from ${oldIds.length} to ${newIds.length}.  Restarting streams.`);
+
+                        const logMsg = `Following count changed from ${oldIds.length} to ${newIds.length}.  Restarting streams.`;
+                        console.log(logMsg);
+                        slack.log(logMsg);
+
                         stopStream();
                         startStream(client, {
                             follow: newIds.toString()

--- a/streams/messages/index.js
+++ b/streams/messages/index.js
@@ -14,10 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const IncomingWebhook = require('@slack/client').IncomingWebhook;
-
-const url = process.env.slackHitUrl;
-const webhook = new IncomingWebhook(url);
+const slack = require('../slack');
 
 //params needs to be user_id || screen_name and text e.g {user_id:22123, text: 'hello'}
 module.exports.sendMessage = (client, params, tweetLink) => {
@@ -28,14 +25,10 @@ module.exports.sendMessage = (client, params, tweetLink) => {
             console.log('ERROR: Unable to send message after matching image');
         }
     });
+
+    // log the hit in slack
     const slackMessage = `${params.text}, Link to tweet: ${tweetLink}`;
-    webhook.send(slackMessage, function(err, header, statusCode) {
-        if (err) {
-          console.log('Error:', err);
-        } else {
-          console.log('Received', statusCode, 'from Slack');
-        }
-      });
+    slack.hit(slackMessage);
 };
 
 

--- a/streams/slack/index.js
+++ b/streams/slack/index.js
@@ -1,0 +1,27 @@
+(function() {
+    const IncomingWebhook = require('@slack/client').IncomingWebhook;
+
+    const searchWebhook = new IncomingWebhook(process.env.slackSearchUrl);
+    const logWebhook = new IncomingWebhook(process.env.slackLogUrl);
+    const hitWebhook = new IncomingWebhook(process.env.slackHitUrl);
+
+    let _handleResponse = (err) => {
+        if (err) console.log('Error:', err);
+    };
+
+    let log = (msg) => {
+        logWebhook.send(msg,_handleResponse);
+    };
+
+    let search = (msg) => {
+        searchWebhook.send(msg,_handleResponse);
+    };
+
+    let hit = (msg) => {
+        hitWebhook.send(msg,_handleResponse);
+    };
+
+    module.exports.log = log;
+    module.exports.search = search;
+    module.exports.hit = hit;
+})();


### PR DESCRIPTION
Move slack logging into its own module and log three categories of tweets to three channels:

  - all received tweets from those we follow
  - all tweets that are searched in TellFinder
  - all tweets that contain matching images